### PR TITLE
Article title with no permission listed in CustomerFAQExplorer

### DIFF
--- a/Kernel/Modules/CustomerFAQExplorer.pm
+++ b/Kernel/Modules/CustomerFAQExplorer.pm
@@ -251,6 +251,24 @@ sub Run {
         $SortBy = 'Changed';
         $OrderBy = 'Down';
         $SearchLimit = 10;
+
+        # Need GetSubCategories => 1, so cannot use $CategoryIDsRef
+        $FAQSearch{CategoryIDs} = $FAQObject->CustomerCategorySearch(
+            CustomerUser  => $Self->{UserLogin},
+            GetSubCategories => 1,
+            Mode          => 'Customer',
+            UserID        => $Self->{UserID},
+        );
+    }
+
+    # search mode
+    else {
+        $FAQSearch{CategoryIDs} = $FAQObject->CustomerCategorySearch(
+            CustomerUser  => $Self->{UserLogin},
+            GetSubCategories => 1,
+            Mode          => 'Customer',
+            UserID        => $Self->{UserID},
+        );
     }
 
     # search all FAQ articles within the given category


### PR DESCRIPTION
See https://github.com/RotherOSS/FAQ/issues/11

Add CustomerUser's category list to $FAQObject->FAQSearch()'s parameters.
Result of CustomerCategorySearch() has checked his/her permissions, search result is restricted by his/her viewable categories.

We want to target whole articles, Need  'GetSubCategories => 1' options insted of $CategoryIDsRef ( only direct child).

If you have a better idea, I follow it.
