### PR TITLE
Add option to hide empty categories in customer FAQ Explorer

### DIFF
--- a/Kernel/Config/Files/XML/FAQ.xml
+++ b/Kernel/Config/Files/XML/FAQ.xml
@@ -617,6 +617,13 @@ Your OTOBO Notification Master
             <Item ValueType="String" ValueRegex="^[0-9]{1,3}$">50</Item>
         </Value>
     </Setting>
+    <Setting Name="FAQ::Frontend::CustomerFAQExplorer###HideEmptyCategories" Required="1" Valid="1">
+        <Description Translatable="1">Hide categories in the FAQ Explorer that have no visible articles for the customer.</Description>
+        <Navigation>Frontend::Customer::View::FAQExplorer</Navigation>
+        <Value>
+            <Item ValueType="Checkbox">0</Item>
+        </Value>
+    </Setting>
     <Setting Name="PublicFrontend::CommonParam###Action" Required="1" Valid="1">
         <Description Translatable="1">Default value for the Action parameter for the public frontend. The Action parameter is used in the scripts of the system.</Description>
         <Navigation>Frontend::Public</Navigation>

--- a/Kernel/Language/de_FAQ.pm
+++ b/Kernel/Language/de_FAQ.pm
@@ -457,6 +457,8 @@ sub Data {
         '';
     $Self->{Translation}->{'Maximum size of the titles in a FAQ article to be shown in the FAQ Explorer in the public interface.'} =
         '';
+    $Self->{Translation}->{'Hide categories in the FAQ Explorer that have no visible articles for the customer.'} =
+        'Kategorien im FAQ-Explorer ausblenden, die keine sichtbaren Artikel für den Kunden haben.';
     $Self->{Translation}->{'Maximum size of the titles in a FAQ article to be shown in the FAQ Search in the agent interface.'} =
         '';
     $Self->{Translation}->{'Maximum size of the titles in a FAQ article to be shown in the FAQ Search in the customer interface.'} =

--- a/Kernel/Language/en_GB_FAQ.pm
+++ b/Kernel/Language/en_GB_FAQ.pm
@@ -457,6 +457,8 @@ sub Data {
         '';
     $Self->{Translation}->{'Maximum size of the titles in a FAQ article to be shown in the FAQ Explorer in the public interface.'} =
         '';
+    $Self->{Translation}->{'Hide categories in the FAQ Explorer that have no visible articles for the customer.'} =
+        '';
     $Self->{Translation}->{'Maximum size of the titles in a FAQ article to be shown in the FAQ Search in the agent interface.'} =
         '';
     $Self->{Translation}->{'Maximum size of the titles in a FAQ article to be shown in the FAQ Search in the customer interface.'} =

--- a/Kernel/Modules/CustomerFAQExplorer.pm
+++ b/Kernel/Modules/CustomerFAQExplorer.pm
@@ -192,6 +192,8 @@ sub Run {
         UserID => $Self->{UserID},
     );
 
+    my $HideEmptyCategories = $Config->{HideEmptyCategories} // 0;
+
     # check if there are subcategories
     if ( $CategoryIDsRef && ref $CategoryIDsRef eq 'ARRAY' && @{$CategoryIDsRef} ) {
 
@@ -205,7 +207,14 @@ sub Run {
             Data => {},
         );
 
+        # get default interface settings
+        my $Interface = $FAQObject->StateTypeGet(
+            Name   => 'external',
+            UserID => $Self->{UserID},
+        );
+
         # show data for each subcategory
+        CATEGORY:
         for my $SubCategoryID ( @{$CategoryIDsRef} ) {
 
             my %SubCategoryData = $FAQObject->CategoryGet(
@@ -220,13 +229,33 @@ sub Run {
             );
 
             # get the number of FAQ articles in this category
-            $SubCategoryData{ArticleCount} = $FAQObject->FAQCount(
-                CategoryIDs  => [$SubCategoryID],
-                ItemStates   => $InterfaceStates,
-                OnlyApproved => 1,
-                Valid        => 1,
-                UserID       => $Self->{UserID},
-            );
+            # if HideEmptyCategories is enabled, only count visible articles for this customer
+            if ($HideEmptyCategories) {
+                my @VisibleItemIDs = $FAQObject->FAQSearch(
+                    CategoryIDs  => [$SubCategoryID],
+                    States       => $InterfaceStates,
+                    Interface    => $Interface,
+                    Approved     => 1,
+                    ValidIDs     => [1],
+                    Limit        => 1,
+                    UserID       => $Self->{UserID},
+                );
+                $SubCategoryData{ArticleCount} = scalar @VisibleItemIDs;
+            }
+            else {
+                $SubCategoryData{ArticleCount} = $FAQObject->FAQCount(
+                    CategoryIDs  => [$SubCategoryID],
+                    ItemStates   => $InterfaceStates,
+                    OnlyApproved => 1,
+                    Valid        => 1,
+                    UserID       => $Self->{UserID},
+                );
+            }
+
+            # skip category if it has no visible articles and HideEmptyCategories is enabled
+            if ( $HideEmptyCategories && !$SubCategoryData{ArticleCount} && !$SubCategoryData{SubCategoryCount} ) {
+                next CATEGORY;
+            }
 
             # output the category data
             $LayoutObject->Block(


### PR DESCRIPTION
Pull Request for Issue #49 

- Add SysConfig option FAQ::Frontend::CustomerFAQExplorer###HideEmptyCategories
- Implement customer-aware article counting in CustomerFAQExplorer.pm
- Add German translation for the new option
- Categories without visible articles for the customer are now hidden when enabled